### PR TITLE
Fix broken stuff from name change.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# crypto
+# accumulator
 Cryptographic accumulators in Rust, implemented over a generic group interface. Batteries (RSA and
 Ristretto group implementations) included!
 

--- a/benches/accumulator.rs
+++ b/benches/accumulator.rs
@@ -2,10 +2,10 @@
 #[macro_use]
 extern crate criterion;
 
+use accumulator::group::{Rsa2048, UnknownOrderGroup};
+use accumulator::hash::hash_to_prime;
+use accumulator::{Accumulator, MembershipProof};
 use criterion::Criterion;
-use crypto::accumulator::{Accumulator, MembershipProof};
-use crypto::group::{Rsa2048, UnknownOrderGroup};
-use crypto::hash::hash_to_prime;
 use rand::Rng;
 use rug::Integer;
 

--- a/benches/group/comparison.rs
+++ b/benches/group/comparison.rs
@@ -3,7 +3,7 @@
 extern crate criterion;
 
 use criterion::Criterion;
-use crypto::group::{ElemFrom, Group, Rsa2048};
+use accumulator::group::{ElemFrom, Group, Rsa2048};
 use rug::Integer;
 use std::str::FromStr;
 

--- a/benches/hash/hashes.rs
+++ b/benches/hash/hashes.rs
@@ -3,7 +3,7 @@
 extern crate criterion;
 
 use criterion::Criterion;
-use crypto::hash::{blake2b, hash_to_prime};
+use accumulator::hash::{blake2b, hash_to_prime};
 use rand::Rng;
 
 fn bench_blake2() {

--- a/benches/hash/primality.rs
+++ b/benches/hash/primality.rs
@@ -2,8 +2,8 @@
 #[macro_use]
 extern crate criterion;
 
+use accumulator::hash::primality::passes_miller_rabin_base_2;
 use criterion::Criterion;
-use crypto::hash::primality::passes_miller_rabin_base_2;
 use rand::Rng;
 use rug::integer::Order;
 use rug::Integer;

--- a/benches/proof/poe.rs
+++ b/benches/proof/poe.rs
@@ -3,9 +3,9 @@
 extern crate criterion;
 
 use criterion::Criterion;
-use crypto::group::{ElemFrom, Rsa2048, UnknownOrderGroup};
-use crypto::proof::Poe;
-use crypto::util::int;
+use accumulator::group::{ElemFrom, Rsa2048, UnknownOrderGroup};
+use accumulator::proof::Poe;
+use accumulator::util::int;
 
 fn bench_poe_rsa() {
   let base = Rsa2048::unknown_order_elem();

--- a/benches/proof/pokcr.rs
+++ b/benches/proof/pokcr.rs
@@ -2,10 +2,10 @@
 #[macro_use]
 extern crate criterion;
 
+use accumulator::group::{ElemFrom, Rsa2048};
+use accumulator::proof::Pokcr;
+use accumulator::util::int;
 use criterion::Criterion;
-use crypto::group::{ElemFrom, Rsa2048};
-use crypto::proof::Pokcr;
-use crypto::util::int;
 
 fn bench_pokcr_rsa() {
   let witnesses = [Rsa2048::elem(2), Rsa2048::elem(3)];

--- a/benches/proof/poke2.rs
+++ b/benches/proof/poke2.rs
@@ -2,11 +2,11 @@
 #[macro_use]
 extern crate criterion;
 
+use accumulator::group::Rsa2048;
+use accumulator::group::{ElemFrom, UnknownOrderGroup};
+use accumulator::proof::Poke2;
+use accumulator::util::int;
 use criterion::Criterion;
-use crypto::group::Rsa2048;
-use crypto::group::{ElemFrom, UnknownOrderGroup};
-use crypto::proof::Poke2;
-use crypto::util::int;
 
 fn bench_poke2_rsa() {
   let base = Rsa2048::unknown_order_elem();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,11 @@
 #[macro_use]
 extern crate lazy_static;
 
-pub mod accumulator;
+mod accumulator;
+pub use accumulator::*;
 pub mod group;
 pub mod hash;
 pub mod proof;
 pub mod util;
-pub mod vector_commitment;
+mod vector_commitment;
+pub use vector_commitment::*;

--- a/tests/accumulator.rs
+++ b/tests/accumulator.rs
@@ -1,6 +1,6 @@
-use crypto::accumulator::Accumulator;
-use crypto::group::Rsa2048;
-use crypto::hash::hash_to_prime;
+use accumulator::group::Rsa2048;
+use accumulator::hash::hash_to_prime;
+use accumulator::Accumulator;
 use rand::Rng;
 
 /// Adds 10,000 random primes to accumulator (unverified), then tests 100 more random additions


### PR DESCRIPTION
Runs `cargo build/test/bench` without errors now. Also fixed `README`.

Other main change is in `lib.rs`: Made `mod accumulator` and `mod vector_commitment` private and adding `pub use accumulator::*` and `pub use vector_commitment::*` to avoid constructions like `accumulator::accumulator::Accumulator` (instead, simply `accumulator::Accumulator`)