### PR TITLE
Class group style

### DIFF
--- a/src/group/class.rs
+++ b/src/group/class.rs
@@ -464,7 +464,7 @@ mod tests {
   }
 
   #[test]
-  // this test should be restructured to not construct ClassElems but it will do for now
+  // REVIEW: this test should be restructured to not construct ClassElems but it will do for now
   fn test_normalize_basic() {
     let unnormalized = construct_raw_elem_from_strings(
       "16",


### PR DESCRIPTION
some changes I realized would be good to make after I had merged the class-groups branch
- use int instead of Integer::from
- generalize ElemFrom impl for class groups