### PR TITLE
fix an error which is displayed in benchmark (#56)

### DIFF
--- a/src/uint.rs
+++ b/src/uint.rs
@@ -50,7 +50,7 @@ macro_rules! u_types {
         fn as_mpz(&self) -> mpz_t {
           mpz_t {
             size: self.size as i32,
-            d: self.data(),
+            d: std::ptr::NonNull::new((self.data())).unwrap(),
             alloc: $size,
           }
         }
@@ -533,7 +533,7 @@ fn i32_to_mpz(i: i32, data: &mut u64) -> mpz_t {
   *data = i.abs() as u64;
   mpz_t {
     size: i.signum(),
-    d: mut_ptr(&data),
+    d: std::ptr::NonNull::new(data).unwrap() ,
     alloc: 1,
   }
 }

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -16,6 +16,7 @@ use std::cmp::{min, Ord, Ordering, PartialOrd};
 use std::convert::From;
 use std::mem::transmute;
 use std::ops;
+use std::ptr;
 
 macro_rules! u_types {
   ($($t:ident,$size:expr),+) => {


### PR DESCRIPTION
**What problem does this PR solve?**

Issue Number: #56

Problem Summary:

*-ptr is not using NonNull

**What is changed and how it works?**

What's Changed:

There is an error which is displayed in benchmark , fix it now

How it Works:

using NonNull when use *-ptr

**Release note**
fix an error which is displayed in benchmark